### PR TITLE
Fix catalog images overlay

### DIFF
--- a/catalogo.html
+++ b/catalogo.html
@@ -8,7 +8,7 @@
   </head>
   <body class="bg-black">
     <header
-      class="flex items-center justify-between p-4 bg-gray-900 text-white shadow-md"
+      class="fixed top-0 left-0 z-50 flex w-full items-center justify-between p-4 bg-gray-900 text-white shadow-md"
     >
       <button
         onclick="window.location.href='index.html'"
@@ -19,7 +19,7 @@
       <img src="vite.svg" alt="Logo del sistema" class="h-8" />
     </header>
 
-    <div id="gallery"></div>
+    <div id="gallery" class="relative z-0"></div>
 
     <a
       href="https://wa.me/524491952828?text=%C2%BFMe%20das%20informaci%C3%B3n%20sobre%20unos%20papos%20que%20me%20interesa%20comprar%3F"
@@ -47,7 +47,7 @@
       for (let i = 1; i <= 483; i++) {
         const img = document.createElement('img');
         img.src = `https://images.priceshoes.digital/catalogos/1254768_${i}.jpg`;
-        img.className = 'w-screen h-screen object-contain';
+        img.className = 'block w-screen h-screen object-contain';
         container.appendChild(img);
       }
     </script>


### PR DESCRIPTION
## Summary
- Keep catalog header fixed and above gallery images
- Ensure catalog images stack below header and WhatsApp button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `(cd frontend && npm test)` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688d97e65e2483259a7a1ca293484a93